### PR TITLE
[generator] Init shell generator Fix #53

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -9,6 +9,7 @@ Supported generators
 
 - logger, generate methods to match `log.LoggableStruct` interface
 - go template, render template using `text/template`
+- shell, call external commands like `protoc`
 
 ````yaml
 loggers:
@@ -32,9 +33,13 @@ logger
 
 - [ ] use assert in test
 - [ ] generate interface check
-- [ ] return error in Render, better error handling
-- [ ] write to buffer and then run go format like https://github.com/dyweb/Ayi/blob/master/cmd/gotmpl.go
+- [x] return error in Render, better error handling
+- [x] write to buffer and then run go format like https://github.com/dyweb/Ayi/blob/master/cmd/gotmpl.go
 
 gotmpl
 
-- [ ] replace Ayi's gotmpl
+- [x] replace Ayi's gotmpl
+
+shell
+
+- [ ] support using `sh -c`

--- a/generator/config.go
+++ b/generator/config.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	Loggers     []LoggerConfig     `yaml:"loggers"`
 	GoTemplates []GoTemplateConfig `yaml:"gotmpls"`
+	Shells      []ShellConfig      `yaml:"shells"`
 	// set when traversing the folders
 	pkg  string
 	file string
@@ -20,7 +21,7 @@ func NewConfig(pkg string, file string) *Config {
 	return &Config{pkg: pkg, file: file}
 }
 
-func (c *Config) Render() ([]byte, error) {
+func (c *Config) RenderGommon() ([]byte, error) {
 	body := &bytes.Buffer{}
 	header := &bytes.Buffer{}
 	fmt.Fprintf(header, Header(generatorName, c.file))
@@ -51,6 +52,19 @@ func (c *Config) RenderGoTemplate(root string) error {
 	}
 	for _, t := range c.GoTemplates {
 		if err := t.Render(root); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Config) RenderShell(root string) error {
+	if len(c.Shells) == 0 {
+		log.Debugf("no shell specified in file %s", c.file)
+		return nil
+	}
+	for _, s := range c.Shells {
+		if err := s.Render(root); err != nil {
 			return err
 		}
 	}

--- a/generator/gommon.example.yml
+++ b/generator/gommon.example.yml
@@ -1,0 +1,21 @@
+# TODO: the example is not testable
+loggers:
+  - struct: "*YAMLConfig"
+    receiver: c
+gotmpls:
+  - src: logger_generated.go.tmpl
+    dst: logger_generated.go
+    go: true
+    data:
+      - Trace
+      - Debug
+      - Info
+      - Warn
+      - Error
+shells:
+  - code: protoc --proto_path=$GOPATH/src/:. --gogo_out=plugins=grpc:. rpc.proto
+    shell: true
+    cd: true
+  - code: go version
+    shell: false
+    cd: false

--- a/generator/gotmpl.go
+++ b/generator/gotmpl.go
@@ -7,6 +7,8 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+
+	"github.com/dyweb/gommon/util/fsutil"
 )
 
 type GoTemplateConfig struct {
@@ -41,7 +43,7 @@ func (c *GoTemplateConfig) Render(root string) error {
 	} else {
 		b = buf.Bytes()
 	}
-	if err = WriteFile(join(root, c.Dst), b); err != nil {
+	if err = fsutil.WriteFile(join(root, c.Dst), b); err != nil {
 		return err
 	}
 	log.Debugf("rendered go tmpl %s to %s", join(root, c.Src), join(root, c.Dst))

--- a/generator/shell.go
+++ b/generator/shell.go
@@ -1,0 +1,41 @@
+package generator
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/dyweb/gommon/util/fsutil"
+	"github.com/kballard/go-shellquote"
+	"github.com/pkg/errors"
+)
+
+// https://github.com/dyweb/gommon/issues/53
+type ShellConfig struct {
+	Code  string `yaml:"code"`
+	Shell bool   `yaml:"shell"`
+	Cd    bool   `yaml:"cd"`
+}
+
+func (c *ShellConfig) Render(root string) error {
+	log.Debugf("cmd %s shell %t cd %t", c.Code, c.Shell, c.Cd)
+	var cmd *exec.Cmd
+	if c.Shell {
+		cmd = exec.Command("sh", "-c", c.Code)
+	} else {
+		if segments, err := shellquote.Split(c.Code); err != nil {
+			return errors.Wrap(err, "can't split command into []string")
+		} else {
+			cmd = exec.Command(segments[0], segments[1:]...)
+		}
+	}
+	if c.Cd {
+		cmd.Dir = join(fsutil.Cwd(), root)
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "error executing command %s", c.Code)
+	}
+	return nil
+}

--- a/generator/testdata/pkg/gommon.yml
+++ b/generator/testdata/pkg/gommon.yml
@@ -2,3 +2,16 @@
 loggers:
   - struct: "*Config"
     receiver: c
+shells:
+  - code: go version
+    shell: false
+  - code: echo $GOPATH
+    shell: true
+  - code: echo $GOPATH
+    shell: false
+  - code: pwd
+    shell: true
+    cd: false
+  - code: pwd
+    shell: true
+    cd: true

--- a/generator/testdata/pkg/server/gommon.yml
+++ b/generator/testdata/pkg/server/gommon.yml
@@ -2,3 +2,10 @@
 loggers:
   - struct: "*Server"
     receiver: srv
+shells:
+  - code: pwd
+    shell: true
+    cd: false
+  - code: pwd
+    shell: true
+    cd: true

--- a/generator/util.go
+++ b/generator/util.go
@@ -1,11 +1,9 @@
 package generator
 
 import (
-	"io/ioutil"
 	"path/filepath"
 
 	"github.com/dyweb/gommon/util/fsutil"
-	"github.com/pkg/errors"
 )
 
 func DefaultIgnores() *fsutil.Ignores {
@@ -25,12 +23,13 @@ func DefaultIgnores() *fsutil.Ignores {
 // NOTE: 0664 is octal literal in Go, the code would compile for 664, but the result file mode is incorrect
 // learned this the hard way https://github.com/dyweb/gommon/issues/41
 // stat -c %a pkg.go
-func WriteFile(f string, b []byte) error {
-	if err := ioutil.WriteFile(f, b, 0664); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
+// NOTE: this code is now in
+//func WriteFile(f string, b []byte) error {
+//	if err := ioutil.WriteFile(f, b, 0664); err != nil {
+//		return errors.WithStack(err)
+//	}
+//	return nil
+//}
 
 func join(s ...string) string {
 	return filepath.Join(s...)

--- a/generator/util_test.go
+++ b/generator/util_test.go
@@ -1,24 +1,16 @@
 package generator
 
-import (
-	"io/ioutil"
-	"os"
-	"testing"
-
-	asst "github.com/stretchr/testify/assert"
-)
-
 // https://github.com/dyweb/gommon/issues/41
 // NOTE: octal literal is needed for file permission, and it starts with 0 ...
-func Test_WriteFile(t *testing.T) {
-	t.Skip("breaks on travis") // https://travis-ci.org/dyweb/gommon/jobs/337322278
-	assert := asst.New(t)
-	ioutil.WriteFile("/tmp/mod_666", []byte("you can't see me"), 666)
-	info, _ := os.Stat("/tmp/mod_666")
-	assert.Equal("--w--wx---", info.Mode().String())
-	ioutil.WriteFile("/tmp/mod_0666", []byte("you can see me now"), 0666)
-	info, _ = os.Stat("/tmp/mod_0666")
-	assert.Equal("-rw-rw-r--", info.Mode().String())
-	WriteFile("/tmp/mod_0664", []byte("normal file mode"))
-	assert.Equal("-rw-rw-r--", info.Mode().String())
-}
+//func Test_WriteFile(t *testing.T) {
+//	t.Skip("breaks on travis") // https://travis-ci.org/dyweb/gommon/jobs/337322278
+//	assert := asst.New(t)
+//	ioutil.WriteFile("/tmp/mod_666", []byte("you can't see me"), 666)
+//	info, _ := os.Stat("/tmp/mod_666")
+//	assert.Equal("--w--wx---", info.Mode().String())
+//	ioutil.WriteFile("/tmp/mod_0666", []byte("you can see me now"), 0666)
+//	info, _ = os.Stat("/tmp/mod_0666")
+//	assert.Equal("-rw-rw-r--", info.Mode().String())
+//	WriteFile("/tmp/mod_0664", []byte("normal file mode"))
+//	assert.Equal("-rw-rw-r--", info.Mode().String())
+//}

--- a/runner/README.md
+++ b/runner/README.md
@@ -1,1 +1,6 @@
 # Command runner
+
+TODO
+
+- github.com/kballard/go-shellquote saw it from https://github.com/github/hub
+- [ ] https://github.com/mvdan/sh A shell parser, formatter and interpreter (POSIX/Bash/mksh)

--- a/runner/example.config.yml
+++ b/runner/example.config.yml
@@ -35,7 +35,7 @@ scripts:
     serve:
         - cmd: Ayi web static
           desc: serve static web content
-          # run in background, all the background commands are run in parrallel, since they won't end in a short time
+          # run in background, all the background commands are run in parallel, since they won't end in a short time
           background: true
           # restart if the running process exit
           restart: true

--- a/util/fsutil/file.go
+++ b/util/fsutil/file.go
@@ -1,0 +1,15 @@
+package fsutil
+
+import (
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+)
+
+// WriteFile use 0666 as permission and wrap standard error
+func WriteFile(path string, data []byte) error {
+	if err := ioutil.WriteFile(path, data, 0664); err != nil {
+		return errors.Wrap(err, "can't write file")
+	}
+	return nil
+}

--- a/util/fsutil/path.go
+++ b/util/fsutil/path.go
@@ -1,8 +1,6 @@
 package fsutil
 
 import (
-	"github.com/pkg/errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -41,14 +39,6 @@ func DirExists(path string) bool {
 	} else {
 		return i.IsDir()
 	}
-}
-
-// WriteFile use 0666 as permission and wrap standard error
-func WriteFile(path string, data []byte) error {
-	if err := ioutil.WriteFile(path, data, 0666); err != nil {
-		return errors.Wrap(err, "can't write file")
-	}
-	return nil
 }
 
 func join(s ...string) string {


### PR DESCRIPTION
- use `sh -c` if `shell` flag is set
- use `shellquote` package to split fields instead of simply
strings.Fields, which does not met user's expectation most times
  - saw it in github's hub https://github.com/github/hub
- use `cd` flag to specify if switching to folder of `gommon.yml` file
is required
- sync execution, no parallel, pipe to stdin/out/err