### PR TITLE
[error] Implement fmt.Formatter #62

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -3,6 +3,7 @@ package errors
 import "fmt"
 
 type TracedError interface {
+	fmt.Formatter
 	ErrorStack() *Stack
 }
 
@@ -20,6 +21,19 @@ func (fresh *FreshError) Error() string {
 
 func (fresh *FreshError) ErrorStack() *Stack {
 	return fresh.stack
+}
+
+func (fresh *FreshError) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		// TODO: print stack if s.Flag('+')
+		fallthrough
+	case 's':
+		s.Write([]byte(fresh.msg))
+	case 'q':
+		// %q	a double-quoted string safely escaped with Go syntax
+		fmt.Fprintf(s, "%q", fresh.msg)
+	}
 }
 
 var _ error = (*WrappedError)(nil)
@@ -82,4 +96,16 @@ func (wrapped *WrappedError) Error() string {
 
 func (wrapped *WrappedError) ErrorStack() *Stack {
 	return wrapped.stack
+}
+
+func (wrapped *WrappedError) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		// TODO: print stack if s.Flag('+')
+		fallthrough
+	case 's':
+		s.Write([]byte(wrapped.Error()))
+	case 'q':
+		fmt.Fprintf(s, "%q", wrapped.Error())
+	}
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -3,14 +3,17 @@ package errors
 import (
 	"os"
 	"testing"
+	"fmt"
 
 	asst "github.com/stretchr/testify/assert"
+	"github.com/dyweb/gommon/util/testutil"
 )
 
 func TestNew(t *testing.T) {
 	assert := asst.New(t)
 	err := New("don't let me go")
 	assert.NotNil(err)
+	assert.Equal("don't let me go", fmt.Sprintf("%v", err))
 	terr, ok := err.(TracedError)
 	assert.True(ok)
 	printFrames(terr.ErrorStack().Frames())
@@ -32,20 +35,27 @@ func TestWrap(t *testing.T) {
 	assert.Nil(n)
 
 	errw := Wrap(os.ErrClosed, "can't open closed file")
+	assert.Equal("can't open closed file: file already closed", fmt.Sprintf("%v", errw))
 	terr, ok := errw.(TracedError)
 	assert.True(ok)
-	printFrames(terr.ErrorStack().Frames())
+	if testutil.Dump().B() {
+		printFrames(terr.ErrorStack().Frames())
+	}
 	assert.Equal(3, len(terr.ErrorStack().Frames()))
 
 	errw = Wrap(freshErr(), "wrap again")
 	terr, ok = errw.(TracedError)
 	assert.True(ok)
-	printFrames(terr.ErrorStack().Frames())
+	if testutil.Dump().B() {
+		printFrames(terr.ErrorStack().Frames())
+	}
 	assert.Equal(4, len(terr.ErrorStack().Frames()))
 
 	errw = Wrap(wrappedStdErr(), "wrap again")
 	terr, ok = errw.(TracedError)
 	assert.True(ok)
-	printFrames(terr.ErrorStack().Frames())
+	if testutil.Dump().B() {
+		printFrames(terr.ErrorStack().Frames())
+	}
 	assert.Equal(4, len(terr.ErrorStack().Frames()))
 }


### PR DESCRIPTION
- just print string, so `t.Log`, `log.Infof("err %v")` would work, `%s` and `%q` also works
- didn't support print stack ...