### PR TITLE
[test] Fix #39 Init test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 vendor
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 sudo: false
 
 go:
-  - 1.9.x
   - "1.10"
   - tip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,7 @@ script:
   - make test
   - make test-race
   - make vet
-  # TODO: gommon doesn't have coverage ... amazing ..
+  - make test-cover
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ test:
 
 .PHONY: test-cover
 test-cover:
-	go test -coverprofile=c.out $(PKGS)
+# https://github.com/codecov/example-go
+	go test -coverprofile=coverage.txt -covermode=atomic $(PKGS)
 
 .PHONY: test-race
 test-race:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ install:
 test:
 	go test -v -cover $(PKGS)
 
+.PHONY: test-cover
+test-cover:
+	go test -coverprofile=c.out $(PKGS)
+
 .PHONY: test-race
 test-race:
 	go test -race $(PKGS)


### PR DESCRIPTION
- go 1.10 has coverprofile for multiple packages
- [x] go 1.9 might break, if that is the case, I will drop go 1.9 support